### PR TITLE
Fix for #6: Fall back to parent of clicked element

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -154,7 +154,10 @@ export default class FocusPlugin extends Plugin {
 			if (!markdownView || (markdownView.getMode() !== 'preview') || !(evt.target instanceof Element) || !this.observeHead)
 				return;
 
-			const element = evt.target;
+			// try to use parent if it's not a heading (to support clicking on inline blocks in headings)
+			const element = evt.target.hasAttribute('data-heading')
+				? evt.target
+				: evt.target.parentElement || evt.target;
 			const block = element.parentElement;
 
 			// restore


### PR DESCRIPTION
This fixes #6 by falling back to using the parent of the clicked element instead of the clicked element itself if it isn't a heading. It adds support for clicking inline block inside headings, e.g. the inline `` `code` `` in `` # A Heading containing `code` ``.

This could have been implemented otherwise but I chose this approach because
1) it's very non-invasive (only changes one statement in the code) and works well with the existing code base.
2) this feature/fix would/will become obsolete anyway if #5 **or** focusing "only" on lists or other blocks (as mentioned in the README) will ever be implemented.

Thanks for this very useful plugin and feel free to complain about my approach if you don't like it ;)